### PR TITLE
pspline: fix stdev_cut/max iteration bug

### DIFF
--- a/wotan/pspline.py
+++ b/wotan/pspline.py
@@ -22,7 +22,7 @@ def pspline(
     newtime = time.copy()
     detrended_flux = flux.copy() / np.nanmedian(newflux)
 
-    for i in range(stdev_cut):
+    for i in range(constants.PSPLINES_MAXITER):
         mask_outliers = np.ma.where(
             np.abs(1 - detrended_flux) < stdev_cut * np.std(detrended_flux)
         )


### PR DESCRIPTION
Hi Michael,

Currently line 25 of pspline.py seems to iterate over `stdev_cut`. This leads to a TypeError when `stdev_cut` is a float (which generally should be allowed?).

More broadly, I think this might be a bug relative to earlier implementations of this routine, which had this line iterating over `constants.SPLINES_MAXITER`, which I think might be correct.

Thank you for creating and maintaining this very useful tool!
-Luke